### PR TITLE
missing bash line break

### DIFF
--- a/dispatcher-mount
+++ b/dispatcher-mount
@@ -20,5 +20,5 @@ docker run -p 80:8080 -p 443:8443 -itd --rm --name dispatcher \
   --mount type=bind,src=$(pwd)/src/conf.modules.d,dst=/etc/httpd/conf.modules.d,readonly=true \
   --mount type=bind,src=$(pwd)/logs,dst=/var/log/httpd \
   --mount type=tmpfs,dst=/tmp \
-  --env-file scripts/env.sh
+  --env-file scripts/env.sh \
   dispatcher


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing script to mount directories for dispatcher config, where it has a missing line break

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Script can be used out of the box, without modifications. 

## How Has This Been Tested?

Tested on a local laptop

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.