### PR TITLE
Made dispatcher-mount demo script more convenient

### DIFF
--- a/dispatcher-mount
+++ b/dispatcher-mount
@@ -1,24 +1,36 @@
 #!/bin/sh
 
-if [ ! -d $(pwd)/src/conf ]; then
-    echo "*ERROR*"
-    echo "This script is supposed to be run in the root directory of your dispatcher project "
-    echo "though we could not find a directory /etc/httpd in the current directory."
-    echo "Please change to your dispatcher directory and try again."
+VERSION="ams/2.6"
+PATH_TO_CONF="etc/httpd"
+
+if [ ! -d $(pwd)/$VERSION/$PATH_TO_CONF/conf ]; then
+    echo "**** ERROR ****"
+    echo "This script is supposed to be run in the root directory of the dispatcher project, "
+    echo "though we could not find a directory ./$VERSION/$PATH_TO_CONF/conf conf from the current directory."
+    echo "Please change to the projects main directory and try again."
     echo ""
     exit 1
 fi
 
-mkdir logs
+mkdir logs 2> /dev/null
+mkdir cache 2> /dev/null
 
-echo "Starting dispatcher, mounting local configuration from ./etc/httpd"
 
-docker run -p 80:8080 -p 443:8443 -itd --rm --name dispatcher \
-  --mount type=bind,src=$(pwd)/src/conf,dst=/etc/httpd/conf,readonly=true \
-  --mount type=bind,src=$(pwd)/src/conf.d,dst=/etc/httpd/conf.d,readonly=true \
-  --mount type=bind,src=$(pwd)/src/conf.dispatcher.d,dst=/etc/httpd/conf.dispatcher.d,readonly=true \
-  --mount type=bind,src=$(pwd)/src/conf.modules.d,dst=/etc/httpd/conf.modules.d,readonly=true \
+echo ""
+echo "Starting dispatcher, mounting local configuration from ./$VERSION/$PATH_TO_CONF ..."
+echo " Open your browser at http://publish.docker.local/content/we-retail/us/en.html  
+echo " **** Press Ctrl-C to stop **** "
+echo ""
+
+docker run -p 80:8080 -p 443:8443 -it --rm  \
+  --mount type=bind,src=$(pwd)/$VERSION/$PATH_TO_CONF/conf,dst=/etc/httpd/conf,readonly=true \
+  --mount type=bind,src=$(pwd)/$VERSION/$PATH_TO_CONF/conf.d,dst=/etc/httpd/conf.d,readonly=true \
+  --mount type=bind,src=$(pwd)/$VERSION/$PATH_TO_CONF/conf.dispatcher.d,dst=/etc/httpd/conf.dispatcher.d,readonly=true \
+  --mount type=bind,src=$(pwd)/$VERSION/$PATH_TO_CONF/conf.modules.d,dst=/etc/httpd/conf.modules.d,readonly=true \
   --mount type=bind,src=$(pwd)/logs,dst=/var/log/httpd \
+  --mount type=bind,src=$(pwd)/cache,dst=/mnt/var/www/html \
   --mount type=tmpfs,dst=/tmp \
   --env-file scripts/env.sh \
-  dispatcher
+  --name mydispatcher dispatcher | cat
+
+


### PR DESCRIPTION
## Description

Improved dispatcher-mount script

## Related Issue

- Script now runs from the docroot (no need to cd into the config)
- Script mounts the cache file from host for inspection
- Script runs attached, so it can be restarted with ctrl-C 


## Motivation and Context

- I found it a bit inconvenient to cd into ./etc and call the script via full-path
- Also calling dispatcher-mount / dispatcher-kill kind of impeded the flow

## How Has This Been Tested?

- Tested the "new" flow while building the we-retail-sample 
- Tested with  zsh running with vscode 

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.