### PR TITLE
Set loglevel to "trace" and linked basic configs to enabled-* folders

### DIFF
--- a/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_author.vhost
+++ b/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_author.vhost
@@ -1,0 +1,1 @@
+../available_vhosts/aem_author.vhost

--- a/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_flush.vhost
+++ b/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_flush.vhost
@@ -1,0 +1,1 @@
+../available_vhosts/aem_flush.vhost

--- a/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_publish.vhost
+++ b/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_publish.vhost
@@ -1,0 +1,1 @@
+../available_vhosts/aem_publish.vhost

--- a/ams/2.6/etc/httpd/conf.d/variables/ams_default.vars
+++ b/ams/2.6/etc/httpd/conf.d/variables/ams_default.vars
@@ -4,7 +4,7 @@
 ## info for Infos
 ## debug for Debug
 ## trace for Trace
-Define DISP_LOG_LEVEL info
+Define DISP_LOG_LEVEL trace
 
 ## Enable IP whitelisting by setting to 1.  Then put your whitelist rules in /etc/httpd/conf.d/whitelists/*_whitelist.rules
 Define AUTHOR_WHITELIST_ENABLED 0

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
@@ -1,0 +1,1 @@
+../available_farms/001_ams_author_flush_farm.any

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
@@ -1,0 +1,1 @@
+../available_farms/001_ams_publish_flush_farm.any

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
@@ -1,0 +1,1 @@
+../available_farms/002_ams_author_farm.any

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
@@ -1,0 +1,1 @@
+../available_farms/002_ams_publish_farm.any


### PR DESCRIPTION
## Description

- Set loglevel to "trace" 
- Linked basic configs to enabled-* folders

## Related Issue


## Motivation and Context

The documentation states, the default log level is trace (which is a sensible default for a development machine). But this setting was not reflected in the configs (which is now corrected).

Also the configuration did not work as described, as enabled-vhost and enabled-farms were empty (which is frustrating for 1st time users) 

## How Has This Been Tested?

- Running config with we-retail.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.