### PR TITLE
Made launch script more convenient 

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -17,4 +17,8 @@
 /usr/bin/cat /NOTICE
 
 /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg
+
+rm -f /run/httpd/authdigest_shm.*
+rm -f /run/httpd/cgisock.*
+rm -f /run/httpd/httpd.pid
 /usr/sbin/httpd -D FOREGROUND


### PR DESCRIPTION
## Description

Made launch script more convenient so that the dispatcher container can be restarted

## Related Issue

https://github.com/adobe/aem-dispatcher-docker/issues/5

## Motivation and Context

When using a compose tool to organize multiple projects for example, you don't need to remember to always destroy the dispatcher container before running it.

## How Has This Been Tested?

- Built the docker image exactly as described in the documentation, but with the new launch script code
- Used the compose file shared in the issue to run the container
- Stop the container as suggested in the issue
- Rerun the container also as suggested in the issue, and didn't get the error anymore
- To make sure, I've entered the restarted container and checked that the httpd process was actually running

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.