### PR TITLE
Dispatcher symlinks are created via Dockerfile

### DIFF
--- a/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_author.vhost
+++ b/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_author.vhost
@@ -1,1 +1,0 @@
-../available_vhosts/aem_author.vhost

--- a/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_flush.vhost
+++ b/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_flush.vhost
@@ -1,1 +1,0 @@
-../available_vhosts/aem_flush.vhost

--- a/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_publish.vhost
+++ b/ams/2.6/etc/httpd/conf.d/enabled_vhosts/aem_publish.vhost
@@ -1,1 +1,0 @@
-../available_vhosts/aem_publish.vhost

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
@@ -1,1 +1,0 @@
-../available_farms/001_ams_author_flush_farm.any

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
@@ -1,1 +1,0 @@
-../available_farms/001_ams_publish_flush_farm.any

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
@@ -1,1 +1,0 @@
-../available_farms/002_ams_author_farm.any

--- a/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
+++ b/ams/2.6/etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
@@ -1,1 +1,0 @@
-../available_farms/002_ams_publish_farm.any


### PR DESCRIPTION
## Description

The symlinks to the default AMS farms/vhosts are setup as part of the Dockerfile. No need to include them in the source code.

## Related Issue

https://github.com/adobe/aem-dispatcher-docker/issues/6

## Motivation and Context

Docker image fails to build due to existing directory at the target location.

## How Has This Been Tested?

Build locally and started the container to test.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.