### PR TITLE
Add sample configs for we.retail site.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,11 @@ RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/000_ams_catchall_farm.any
 RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_author_flush_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
 RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_publish_flush_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
 RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_author_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
+
+# Setup sample configs
+COPY sample/weretail_filters.any /etc/httpd/conf.dispatcher.d/filters/weretail_filters.any
+COPY sample/weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any
+RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/100_weretail_publish_farm.any
 
 # Install dispatcher
 ARG TARGETARCH

--- a/sample/weretail_filters.any
+++ b/sample/weretail_filters.any
@@ -1,0 +1,11 @@
+/C001 { /type "allow" /url "/content*" /selectors '(coreimg|img)' }
+
+/C002 { /type "allow" /url "/content*" /selectors '(header_include|default)' /extension "html" }
+
+/C003 { /type "allow" /url "/etc/cloudsettings.kernel.js*" /selectors "kernel" /suffix "/libs/settings/cloudsettings/legacy/contexthub" /extension "js" }
+
+/C004 { /type "allow" /url "/libs/granite/security/currentuser.json" }
+
+/C005 { /type "allow" /url "/content*" /selectors '(pagedata|commerce)' /extension "json" }
+
+/C006 { /type "allow" /url "/conf*" /selectors '(seg)' /extension "js" }

--- a/sample/weretail_publish_farm.any
+++ b/sample/weretail_publish_farm.any
@@ -1,0 +1,115 @@
+/weretail-publishfarm {  
+	## client headers which should be passed through to the render instances
+	## (feature supported since dispatcher build 2.6.3.5222)
+	/clientheaders {
+		$include "/etc/httpd/conf.dispatcher.d/clientheaders/ams_publish_clientheaders.any"
+		$include "/etc/httpd/conf.dispatcher.d/clientheaders/ams_common_clientheaders.any"
+	}
+	## hostname globbing for farm selection (virtual domain addressing)
+	/virtualhosts {
+		$include "/etc/httpd/conf.dispatcher.d/vhosts/ams_publish_vhosts.any"
+	}
+	## the load will be balanced among these render instances
+	/renders {
+		$include "/etc/httpd/conf.dispatcher.d/renders/ams_publish_renders.any"
+	}
+	## only handle the requests in the following acl. default is 'none'
+	## the glob pattern is matched against the first request line
+	/filter {
+        $include "/etc/httpd/conf.dispatcher.d/filters/ams_publish_filters.any"
+		$include "/etc/httpd/conf.dispatcher.d/filters/weretail_filters.any"
+	}
+	## if the package is installed on publishers to generate a list of all content with a vanityurl attached
+	## this section will auto-allow the items to bypass the normal dispatcher filters
+	## Reference: https://docs.adobe.com/docs/en/dispatcher/disp-config.html#Enabling%20Access%20to%20Vanity%20URLs%20-%20/vanity_urls
+	#/vanity_urls {
+	#	/url    "/libs/granite/dispatcher/content/vanityUrls.html"
+	#	/file   "/tmp/vanity_urls"
+	#	/delay  300
+	#}
+	## allow propagation of replication posts (should seldomly be used)
+	/propagateSyndPost "0"
+	## the cache is used to store requests from the renders for faster delivery
+	## for a second time.
+	/cache {
+		## The cacheroot must be equal to the document root of the webserver
+		/docroot "${PUBLISH_DOCROOT}"
+		## sets the level upto which files named ".stat" will be created in the 
+		## document root of the webserver. when an activation request for some 
+		## handle is received, only files within the same subtree are affected 
+		## by the invalidation.
+		/statfileslevel "${DEFAULT_STAT_LEVEL}"
+		## caches also authorized data
+		/allowAuthorized "0"
+		## Flag indicating whether the dispatcher should serve stale content if
+		## no remote server is available.
+		/serveStaleOnError "1"
+		## the rules define, which pages should be cached. please note that
+		## - only GET requests are cached
+		## - only requests with an extension are cached
+		## - only requests without query parameters ( ? ) are cached
+		## - only unauthorized pages are cached unless allowUnauthorized is set to 1
+		/rules {
+			$include "/etc/httpd/conf.dispatcher.d/cache/ams_publish_cache.any"
+		}
+		# the invalidate section defines those pages which are 'invalidated' after
+		# any activation. please note that, the activated page itself and all 
+		# related documents are flushed on an modification. for example: if the 
+		# page /foo/bar is activated, all /foo/bar.* files are removed from the
+		# cache.
+		/invalidate {
+			/0000 {
+				/glob "*"
+				/type "deny"
+			}
+			/0001 {
+				/glob "*.html"
+				/type "allow"
+			}
+		}
+		/allowedClients {
+			## By default block all IP from allowing to initiate the invalidation commands
+			/0000 {
+				/glob "*.*.*.*"
+				/type "deny"
+			}
+			## Allow certain IP's like publishers to invalidate cache
+			$include "/etc/httpd/conf.dispatcher.d/cache/ams_publish_invalidate_allowed.any"
+		}
+		## Cache response headers next to a cached file. On the first request to
+		## an uncached resource, all headers matching one of the values found here
+		## are stored in a separate file, next to the cache file. On subsequent
+		## requests to the cached resource, the stored headers are added to the
+		## response.
+		## Note, that file globbing characters are not allowed here.
+		/headers {
+			"Cache-Control"
+			"Content-Disposition"
+			"Content-Type"
+			"Expires"
+			"Last-Modified"
+			"X-Content-Type-Options"
+		}
+		## By default we want to cache every page regardless if it has a query parameter.
+		## For pages that render html differently based on the query parameters 
+		## please add entries to deny the caching of those query parameters in this section
+		/ignoreUrlParams {
+			/0001 { /glob "*" /type "allow" }
+		}
+
+		# A grace period defines the number of seconds a stale, auto-invalidated
+		# resource may still be served from the cache after the last activation
+		# occurring. Auto-invalidated resources are invalidated by any activation,
+		# when their path matches the /invalidate section above. This setting
+		# can be used in a setup, where a batch of activations would otherwise
+		# repeatedly invalidate the entire cache.
+		/gracePeriod "2"
+
+		## Enable TTL evaluates the response headers from the backend, and if they
+		## contain a Cache-Control max-age or Expires date, an auxiliary, empty file
+		## next to the cache file is created, with modification time equal to the
+		## expiry date. When the cache file is requested past the modification time
+		## it is automatically re-requested from the backend.
+		# /enableTTL "1"
+	}
+}


### PR DESCRIPTION
## Description

Added sample configs for we.retail and updated the Dockerfile to copy these into the image.

## Related Issue

https://github.com/adobe/aem-dispatcher-docker/issues/9

## Motivation and Context

Simplify demo/sandbox setups.

## How Has This Been Tested?

Build the image and start it using the standalone command
`docker run -p 80:8080 -p 443:8443 -it --rm --name dispatcher --env-file scripts/env.sh dispatcher`
Browse to http://publish.docker.local/content/we-retail/us/en.html and confirm we.retail is rendering.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.