### PR TITLE
- ensuring correct line ending while building on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
 /.idea/
 logs/
-/dispatcher-docker.iml
+*.iml
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ COPY ams/2.6/etc/httpd /etc/httpd
 # Setup sample configs
 COPY sample/weretail_filters.any /etc/httpd/conf.dispatcher.d/filters/weretail_filters.any
 COPY sample/weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/100_weretail_publish_farm.any
-
 
 # Install dispatcher
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,14 @@ ARG TARGETARCH
 COPY scripts/setup.sh /
 RUN chmod +x /setup.sh
 # ensuring correct file ending on windows systems
-RUN sed -i -e 's/\r$//' /setup.sh
+RUN sed -i -e 's/\r\n/\n/' /setup.sh
 RUN ./setup.sh
 RUN rm /setup.sh
 
 
 COPY scripts/launch.sh /
 # ensuring correct file ending on windows systems
-RUN sed -i -e 's/\r$//' /launch.sh
+RUN sed -i -e 's/\r\n/\n/' /launch.sh
 RUN chmod +x /launch.sh
 
 COPY LICENSE /

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,57 +16,28 @@
 FROM --platform=$TARGETPLATFORM centos:7
 
 #install HTTPD
-RUN yum -y update
-RUN yum -y install httpd mod_ssl procps haproxy iputils tree telnet
+RUN yum -y update && yum -y install httpd mod_ssl procps haproxy iputils tree telnet && yum clean all
 
 #remove default CentOS config
-RUN rm -rf /etc/httpd/conf/*
-RUN rm -rf /etc/httpd/conf.d/*
-RUN rm -rf /etc/httpd/conf.modules.d/*
+RUN rm -rf /etc/httpd/conf/* && rm -rf /etc/httpd/conf.d/* && rm -rf /etc/httpd/conf.modules.d/*
 
 #Copy the AMS base files into the image.
 COPY ams/2.6/etc/httpd /etc/httpd
-RUN mkdir /etc/httpd/conf.d/enabled_vhosts
-RUN ln -s /etc/httpd/conf.d/available_vhosts/aem_author.vhost /etc/httpd/conf.d/enabled_vhosts/aem_author.vhost
-RUN ln -s /etc/httpd/conf.d/available_vhosts/aem_flush_author.vhost /etc/httpd/conf.d/enabled_vhosts/aem_flush_author.vhost
-RUN ln -s /etc/httpd/conf.d/available_vhosts/aem_publish.vhost /etc/httpd/conf.d/enabled_vhosts/aem_publish.vhost
-RUN ln -s /etc/httpd/conf.d/available_vhosts/aem_flush.vhost /etc/httpd/conf.d/enabled_vhosts/aem_flush.vhost
-RUN ln -s /etc/httpd/conf.d/available_vhosts/aem_health.vhost /etc/httpd/conf.d/enabled_vhosts/aem_health.vhost
-
-RUN mkdir /etc/httpd/conf.dispatcher.d/enabled_farms
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/000_ams_catchall_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/000_ams_catchall_farm.any
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_author_flush_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_publish_flush_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_author_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
+COPY haproxy/haproxy.cfg /etc/haproxy
 
 # Install dispatcher
 ARG TARGETARCH
 COPY scripts/setup.sh /
 RUN chmod +x /setup.sh
+# ensuring correct file ending on windows systems
+RUN sed -i -e 's/\r$//' /setup.sh
 RUN ./setup.sh
 RUN rm /setup.sh
 
-# Create default docroots
-RUN mkdir -p /mnt/var/www/html
-RUN chown apache:apache /mnt/var/www/html
-
-RUN mkdir -p /mnt/var/www/default
-RUN chown apache:apache /mnt/var/www/default
-
-RUN mkdir -p /mnt/var/www/author
-RUN chown apache:apache /mnt/var/www/author
-
-# Setup SSL
-RUN mkdir -p /etc/ssl/docker && \
-    openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=GB/ST=London/L=London/O=Adobe/CN=localhost" \
-     -keyout /etc/ssl/docker/localhost.key \
-     -out /etc/ssl/docker/localhost.crt && \
-    cat /etc/ssl/docker/localhost.key /etc/ssl/docker/localhost.crt > /etc/ssl/docker/haproxy.pem
-
-COPY haproxy/haproxy.cfg /etc/haproxy
 
 COPY scripts/launch.sh /
+# ensuring correct file ending on windows systems
+RUN sed -i -e 's/\r$//' /launch.sh
 RUN chmod +x /launch.sh
 
 COPY LICENSE /

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -46,7 +46,7 @@ ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_author_farm.any /etc/
 ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
 
 #set up sample configs
-RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/100_weretail_publish_farm.any
+ln -s /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/100_weretail_publish_farm.any
 #set up dispatcher
 mkdir -p /tmp/dispatcher
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,6 +45,8 @@ ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_publish_flush_farm.an
 ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_author_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
 ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
 
+#set up sample configs
+RUN ln -s /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/100_weretail_publish_farm.any
 #set up dispatcher
 mkdir -p /tmp/dispatcher
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,6 +20,32 @@ if [ "${TARGETARCH}" = "arm64" ]; then
     DISPARCH=aarch64
 fi
 
+# Create default docroots
+mkdir -p /mnt/var/www/html
+chown apache:apache /mnt/var/www/html
+
+mkdir -p /mnt/var/www/default
+chown apache:apache /mnt/var/www/default
+
+mkdir -p /mnt/var/www/author
+chown apache:apache /mnt/var/www/author
+#create and link up default enabled vhosts
+mkdir /etc/httpd/conf.d/enabled_vhosts
+ln -s /etc/httpd/conf.d/available_vhosts/aem_author.vhost /etc/httpd/conf.d/enabled_vhosts/aem_author.vhost
+ln -s /etc/httpd/conf.d/available_vhosts/aem_flush_author.vhost /etc/httpd/conf.d/enabled_vhosts/aem_flush_author.vhost
+ln -s /etc/httpd/conf.d/available_vhosts/aem_publish.vhost /etc/httpd/conf.d/enabled_vhosts/aem_publish.vhost
+ln -s /etc/httpd/conf.d/available_vhosts/aem_flush.vhost /etc/httpd/conf.d/enabled_vhosts/aem_flush.vhost
+ln -s /etc/httpd/conf.d/available_vhosts/aem_health.vhost /etc/httpd/conf.d/enabled_vhosts/aem_health.vhost
+
+#create and link up default enabled vhosts
+mkdir /etc/httpd/conf.dispatcher.d/enabled_farms
+ln -s /etc/httpd/conf.dispatcher.d/available_farms/000_ams_catchall_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/000_ams_catchall_farm.any
+ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_author_flush_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_author_flush_farm.any
+ln -s /etc/httpd/conf.dispatcher.d/available_farms/001_ams_publish_flush_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/001_ams_publish_flush_farm.any
+ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_author_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_author_farm.any
+ln -s /etc/httpd/conf.dispatcher.d/available_farms/002_ams_publish_farm.any /etc/httpd/conf.dispatcher.d/enabled_farms/002_ams_publish_farm.any
+
+#set up dispatcher
 mkdir -p /tmp/dispatcher
 
 curl -o /tmp/dispatcher/dispatcher.tar.gz https://download.macromedia.com/dispatcher/download/dispatcher-apache2.4-linux-$DISPARCH-4.3.5.tar.gz
@@ -29,3 +55,11 @@ cd /tmp/dispatcher
 tar zxvf dispatcher.tar.gz
 
 cp -v dispatcher-apache2.4-4.3.5.so /etc/httpd/modules/mod_dispatcher.so
+
+#set up HA proxy
+# Setup SSL
+mkdir -p /etc/ssl/docker && \
+    openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=GB/ST=London/L=London/O=Adobe/CN=localhost" \
+     -keyout /etc/ssl/docker/localhost.key \
+     -out /etc/ssl/docker/localhost.crt && \
+    cat /etc/ssl/docker/localhost.key /etc/ssl/docker/localhost.crt > /etc/ssl/docker/haproxy.pem


### PR DESCRIPTION


## Description

- Optimising resulting image size.

Ensure that the line endings in the script are correct after copying to docker layer, by removing CR characters with sed. 

Also, moving a lot of setup steps from Dockerfile to `setup.sh` script in order to made the image smaller (by about 200MB). 

## Related Issue

#12 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When user check out repository on Windows and adjusts file endings, the image won't build. It does not happen on linux based systems. Relying on users to configure their git correctly is sometimes not user friendly or against user preferences. 

Change has been only tested on Mac where it still builds correctly. Windows testing is required to verify. 


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.