### PR TITLE
Added back missing haproxy config to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,30 +15,32 @@
 #
 FROM --platform=$TARGETPLATFORM centos:7
 
-#install HTTPD
+# Install HTTPD
 RUN yum -y update && yum -y install httpd mod_ssl procps haproxy iputils tree telnet && yum clean all
 
-#remove default CentOS config
+# Remove default CentOS config
 RUN rm -rf /etc/httpd/conf/* && rm -rf /etc/httpd/conf.d/* && rm -rf /etc/httpd/conf.modules.d/*
 
-#Copy the AMS base files into the image.
+# Copy the AMS base files into the image.
 COPY ams/2.6/etc/httpd /etc/httpd
 # Setup sample configs
 COPY sample/weretail_filters.any /etc/httpd/conf.dispatcher.d/filters/weretail_filters.any
 COPY sample/weretail_publish_farm.any /etc/httpd/conf.dispatcher.d/available_farms/100_weretail_publish_farm.any
 
+# Copy haproxy config
+COPY haproxy/haproxy.cfg /etc/haproxy
+
 # Install dispatcher
 ARG TARGETARCH
 COPY scripts/setup.sh /
 RUN chmod +x /setup.sh
-# ensuring correct file ending on windows systems
+# Ensuring correct file ending on windows systems
 RUN sed -i -e 's/\r\n/\n/' /setup.sh
 RUN ./setup.sh
 RUN rm /setup.sh
 
-
 COPY scripts/launch.sh /
-# ensuring correct file ending on windows systems
+# Ensuring correct file ending on windows systems
 RUN sed -i -e 's/\r\n/\n/' /launch.sh
 RUN chmod +x /launch.sh
 


### PR DESCRIPTION
## Description

The HAProxy config was left out when the setup commands were moved to the script.
## Related Issue

## Motivation and Context

Reverse proxy not working.

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.